### PR TITLE
Fix compilation for nrf with TEST_MODE=1

### DIFF
--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -133,7 +133,8 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
 #if CHIP_CONFIG_SECURITY_TEST_MODE
         {
 #if OPENTHREAD_API_VERSION >= 126
-            const otNetworkKey * otKey = otThreadGetNetworkKey(otInst);
+            const otNetworkKey * otKey;
+            otThreadGetNetworkKey(otInst, otKey);
             for (int i = 0; i < OT_NETWORK_KEY_SIZE; i++)
 #else
             const otMasterKey * otKey = otThreadGetMasterKey(otInst);


### PR DESCRIPTION
Fix the number of args to otThreadGetNetworkKey() when TEST_MODE is enabled.

#### Problem
nrf doesnt compile when TEST_MODE is enabled

#### Change overview
Modified the arguments to match the  signature of otThreadGetNetworkKey().

#### Testing
Verified the compilation is successful.
